### PR TITLE
fix user role change not propagated for organization capacity

### DIFF
--- a/ckanext/sso/plugin.py
+++ b/ckanext/sso/plugin.py
@@ -90,6 +90,7 @@ class SsoPlugin(plugins.SingletonPlugin):
                 if organization:
                     log.info("adding user %s to organization %s with role %s", username, organization['name'], user_org_role)
                     data = {"id" : organization["id"] , "username" : user_id, "role" : user_org_role}
+                    # if the membership already exists, ckan will do an update instead of a create
                     toolkit.get_action("organization_member_create")({'ignore_auth': True}, data)
                 else:
                     log.info("creating organization %s and adding user %s with role %s", expected_org_name, username, user_org_role)

--- a/ckanext/sso/plugin.py
+++ b/ckanext/sso/plugin.py
@@ -54,31 +54,32 @@ class SsoPlugin(plugins.SingletonPlugin):
             user.sysadmin = False
             model.Session.add(user)
             model.Session.commit()
-                
+
             # get users organisation from saml attributes
             try:
                 expected_org_title = saml_attributes["member"][0] # use the first organization in the list only
                 expected_org_name = expected_org_title.replace(' ', '-').lower()
             except (KeyError, IndexError):
-                log.error("%s doesn't have a organisation", username)
+                log.error("%s doesn't have an organisation", username)
                 return resp
-            
+
             # Remove from all orgs other than the one they are meant to be in
             current_orgs = toolkit.get_action("organization_list_for_user")({'ignore_auth': True}, {})
-            IsInOrg = False
+            target_org = None
             for org in current_orgs:
                 if org["name"] == expected_org_name: #if user is already in correct org
-                    IsInOrg = True
+                    target_org = org
                 else:
                     try:
                         toolkit.get_action("organization_member_delete")({'ignore_auth': True}, {"id": org["name"], "username": user_id})
                     except:
                         log.error("Cannot delete from: %s", org["name"])
 
-            if IsInOrg: #If user is already in the org no need to do processing below
+            if target_org is not None and target_org["capacity"] == user_org_role:
+                # if user is already in the org with the correct capacity no need to do processing below
+                log.debug("user %s is already a '%s' in organization %s", username, target_org["name"], user_org_role)
                 return resp
-            
-            # Get all organisations
+
             try:
                 organization = toolkit.get_action("organization_show")({'ignore_auth': True}, {"id": expected_org_name})
             except toolkit.ObjectNotFound:
@@ -87,11 +88,11 @@ class SsoPlugin(plugins.SingletonPlugin):
             # Check if their organisation exist. If it does, add them to it at assigned level
             try:
                 if organization:
-                    log.info("adding user %s to organization %s", username, organization['name'])
+                    log.info("adding user %s to organization %s with role %s", username, organization['name'], user_org_role)
                     data = {"id" : organization["id"] , "username" : user_id, "role" : user_org_role}
                     toolkit.get_action("organization_member_create")({'ignore_auth': True}, data)
                 else:
-                    log.info("creating organization %s with user %s", expected_org_name, username)
+                    log.info("creating organization %s and adding user %s with role %s", expected_org_name, username, user_org_role)
                     org_users = [{"name" : user_id, "capacity": user_org_role}]
                     data = {"name": expected_org_name, "title": expected_org_title, "users": org_users}
                     toolkit.get_action("organization_create")({'ignore_auth': True}, data)


### PR DESCRIPTION
fix when a user role is changed as indicated by the saml attributes during sign in, the member's capacity within the organization is not updated include more logging with assigned role/capacity